### PR TITLE
Make datetime tz aware

### DIFF
--- a/custom_components/variable/helpers.py
+++ b/custom_components/variable/helpers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import datetime
 import logging
 
+import homeassistant.util.dt as dt_util
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -61,6 +63,11 @@ def value_to_type(init_val, dest_type):  # noqa: C901
                 _LOGGER.debug(
                     f"[value_to_type] return value: {value_datetime}, type: {type(value_datetime)}"
                 )
+                if (
+                    value_datetime.tzinfo is None
+                    or value_datetime.tzinfo.utcoffset(value_datetime) is None
+                ):
+                    return value_datetime.replace(tzinfo=dt_util.UTC)
                 return value_datetime
 
         elif dest_type == "number":
@@ -113,6 +120,11 @@ def value_to_type(init_val, dest_type):  # noqa: C901
                 _LOGGER.debug(
                     f"[value_to_type] return value: {value_datetime}, type: {type(value_datetime)}"
                 )
+                if (
+                    value_datetime.tzinfo is None
+                    or value_datetime.tzinfo.utcoffset(value_datetime) is None
+                ):
+                    return value_datetime.replace(tzinfo=dt_util.UTC)
                 return value_datetime
         elif dest_type == "number":
             _LOGGER.debug(


### PR DESCRIPTION
Makes Sensors with Device Class of `timestamp` timezone aware. This is now required by Home Assistant.

Timestamps must be set as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) 

Note that if a timestamp is set without a timezone defined, it will be set as UTC.

Example:
```yaml
service: variable.update_sensor
data:
  replace_attributes: false
  value: "2023-11-20T17:00:00-05:00"
target:
  entity_id: sensor.datetime
```

Fixes #102 